### PR TITLE
refactor: separate PR fetching from processing functions to improve performance

### DIFF
--- a/src/core/pr.ts
+++ b/src/core/pr.ts
@@ -7,33 +7,24 @@ export async function getUserCreatedPRListInPeriod(options: ActivityQueryOptions
   return userCreatedPRList.filter((pr) => pr.author === options.username);
 }
 
-export async function getUserCreatedPRCountInPeriod(
-  options: ActivityQueryOptions,
-): Promise<number> {
-  const userCreatedPRList = await getUserCreatedPRListInPeriod(options);
-
-  return userCreatedPRList.length;
+export async function getUserCreatedPRCountInPeriod(prList: PR[]): Promise<number> {
+  return prList.length;
 }
 
 export async function getUserCreatedPRListInPeriodByLabel(
-  options: ActivityQueryOptions,
+  prList: PR[],
+  labelFilter: string[],
 ): Promise<PR[]> {
-  const userCreatedPRList = await getUserCreatedPRListInPeriod(options);
-
-  return userCreatedPRList.filter((pr) =>
-    options.labelFilter?.some((filter) =>
+  return prList.filter((pr) =>
+    labelFilter.some((filter) =>
       pr.labels.some((label) => label.toLowerCase().includes(filter.toLowerCase())),
     ),
   );
 }
 
-export async function getUserPRCountByLabelInPeriod(
-  options: ActivityQueryOptions,
-): Promise<Record<string, number>> {
-  const userCreatedPRList = await getUserCreatedPRListInPeriod(options);
-
+export async function getUserPRCountByLabelInPeriod(prList: PR[]): Promise<Record<string, number>> {
   const labelCountMap: Record<string, number> = {};
-  userCreatedPRList.map((pr) => {
+  prList.map((pr) => {
     pr.labels.forEach((label) => {
       labelCountMap[label] = (labelCountMap[label] || 0) + 1;
     });

--- a/tests/core/pr.test.ts
+++ b/tests/core/pr.test.ts
@@ -49,7 +49,7 @@ describe('getUserCreatedPRListInPeriod', () => {
 
 describe('getUserCreatedPRCountInPeriod', () => {
   it('returns the number of pull requests created by the user within the specified period', async () => {
-    const result = await getUserCreatedPRCountInPeriod({
+    const prList = await getUserCreatedPRListInPeriod({
       githubToken: process.env.GITHUB_TOKEN ?? '',
       username: 'oliviertassinari',
       repository: 'mui/material-ui',
@@ -57,32 +57,36 @@ describe('getUserCreatedPRCountInPeriod', () => {
       targetBranch: 'mui:v5.x',
     });
 
+    const result = await getUserCreatedPRCountInPeriod(prList);
+
     expect(result).toEqual(14);
   });
 });
 
 describe('getUserCreatedPRListInPeriodByLabel', () => {
   it('filters pull requests that exactly match provided label names (case-sensitive)', async () => {
-    const result = await getUserCreatedPRListInPeriodByLabel({
+    const prList = await getUserCreatedPRListInPeriod({
       githubToken: process.env.GITHUB_TOKEN ?? '',
       username: 'oliviertassinari',
       repository: 'mui/material-ui',
       period: { startDate: '2025-05-01', endDate: '2025-05-31' },
       targetBranch: 'mui:master',
-      labelFilter: ['docs'],
     });
+
+    const result = await getUserCreatedPRListInPeriodByLabel(prList, ['docs']);
 
     expect(result).toMatchSnapshot();
   });
   it('filters pull requests that include provided label keywords (case-insensitive, partial match)', async () => {
-    const result = await getUserCreatedPRListInPeriodByLabel({
+    const prList = await getUserCreatedPRListInPeriod({
       githubToken: process.env.GITHUB_TOKEN ?? '',
       username: 'oliviertassinari',
       repository: 'mui/material-ui',
       period: { startDate: '2025-05-01', endDate: '2025-05-10' },
       targetBranch: 'mui:master',
-      labelFilter: ['regression'],
     });
+
+    const result = await getUserCreatedPRListInPeriodByLabel(prList, ['regression']);
 
     expect(result.length).toBe(3);
     expect(result[0].labels).toContain('regression 🐛');
@@ -94,13 +98,16 @@ describe('getUserCreatedPRListInPeriodByLabel', () => {
 
 describe('getUserPRCountByLabelInPeriod', () => {
   it('counts pull requests created by the user within the specified period, grouped by label, and returns an object like {feat: 10, fix: 2, test: 10, ...}', async () => {
-    const result = await getUserPRCountByLabelInPeriod({
+    const prList = await getUserCreatedPRListInPeriod({
       githubToken: process.env.GITHUB_TOKEN ?? '',
       username: 'oliviertassinari',
       repository: 'mui/material-ui',
       period: { startDate: '2024-09-10', endDate: '2024-09-20' },
       targetBranch: 'mui:v5.x',
     });
+
+    const result = await getUserPRCountByLabelInPeriod(prList);
+
     expect(result).toEqual({
       'scope: docs-infra': 3,
       security: 1,


### PR DESCRIPTION
## Changes

> Write about the features you've implemented or modified.
- This pull request refactors the PR-related core functions to optimize performance and reduce redundant API calls. Now, only the getUserCreatedPRListInPeriod function is responsible for fetching PR data from the API. 
- All other functions (getUserCreatedPRCountInPeriod, getUserCreatedPRListInPeriodByLabel, getUserPRCountByLabelInPeriod) have been updated to accept a pre-fetched PR list as input and process it accordingly.
- This change improves efficiency, enhances testability, and makes the codebase more flexible for future extensions.
- Function signatures and related test cases have been updated to reflect this new structure.

## Check List

> Please describe any areas you'd like the reviewer to pay special attention to.
> [e.g] Code structure, naming, implementation

- [ ]

## Test Step

> Please provide the environment variables to test this PR, and the steps for the executable script.
> It helps reviewers review code faster.

## Screenshots

> Please attach screenshots of the implementation and modified functionality.
> It helps reviewers quickly understand where to focus their attention.
