### PR TITLE
refactor: replace email with user ID in GitHub user info validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ import { fetchGitHubUserInfo, fetchAllPRListInPeriod } from '@octoreport/core';
 
 // Get user information
 const userInfo = await fetchGitHubUserInfo('YOUR_GITHUB_TOKEN');
-// Returns: { login: 'octocat', email: 'octocat@example.com' }
+// Returns: { login: 'octocat', id: 'MDQ6VXNlcjc5OTk1', scopeList: ['read:user', 'repo'] }
 
 // Get all PRs in a period
 const allPRs = await fetchAllPRListInPeriod({

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -49,8 +49,8 @@ export async function fetchGitHubUserInfo(githubToken: string): Promise<GitHubUs
       query: `
         {
           viewer {
+            id
             login
-            email
           }
         }
       `,
@@ -255,7 +255,7 @@ export async function testGitHubToken(githubToken: string): Promise<void> {
           {
             viewer {
               login
-              email
+              id
             }
           }
         `,
@@ -278,11 +278,9 @@ export async function testGitHubToken(githubToken: string): Promise<void> {
       throw new Error('No viewer data in response');
     }
 
-    // Zod 스키마로 검증
     try {
       const validatedUserInfo = GitHubUserInfoSchema.parse(data.data.viewer);
       console.log('✅ Token is valid! User:', validatedUserInfo.login);
-      console.log('📧 Email:', validatedUserInfo.email);
     } catch (error) {
       if (error instanceof z.ZodError) {
         console.error('❌ User info validation failed:', error.message);

--- a/src/schemas/github.ts
+++ b/src/schemas/github.ts
@@ -10,17 +10,16 @@ const UserSchema = z.object({
 
 export const GitHubUserInfoSchema = z.object({
   login: z.string(),
-  email: z.string().email(),
+  id: z.string(),
   scopeList: z.array(z.string()).refine(
     (scopeList) => {
       const hasReadUser = scopeList.includes('read:user');
-      const hasUserEmail = scopeList.includes('user:email');
       const hasRepoScope = scopeList.includes('repo') || scopeList.includes('public_repo');
 
-      return hasReadUser && hasUserEmail && hasRepoScope;
+      return hasReadUser && hasRepoScope;
     },
     {
-      message: `Scope list must include 'read:user', 'user:email', and either 'repo' or 'public_repo'`,
+      message: `Scope list must include 'read:user' and either 'repo' or 'public_repo'`,
     },
   ),
 });


### PR DESCRIPTION
## Changes

> Write about the features you've implemented or modified.

- GitHub user info validation was failing with "User info validation failed" error when users had private email settings, even with proper token scopes including `user:email`.

- **Remove email dependency**: Replaced `email` field with `id` field in `GitHubUserInfoSchema` to avoid private email access issues
- **Simplify token requirements**: Removed `user:email` scope requirement from token validation
- **Update API queries**: Modified GraphQL queries in both `fetchGitHubUserInfo` and `testGitHubToken` to request user `id` instead of `email`
- **Update documentation**: Updated README examples to reflect the new API response structure


## Check List

> Please describe any areas you'd like the reviewer to pay special attention to.
> [e.g] Code structure, naming, implementation

- [ ]

## Test Step

> Please provide the environment variables to test this PR, and the steps for the executable script.
> It helps reviewers review code faster.

## Screenshots

> Please attach screenshots of the implementation and modified functionality.
> It helps reviewers quickly understand where to focus their attention.
